### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SPI Client iOS [![Build Status](https://travis-ci.org/mx51/spi-client-ios.svg?branch=master)](https://travis-ci.org/mx51/spi-client-ios)
+# SPI Client iOS
 
 This is the iOS client library for mx51 in-store integration.
 


### PR DESCRIPTION
There was a link to the old Travis CI pipeline status which is now not used, and has been dead for a while. This was propagated to the CocoaPod;s site too, and looked terrible.

Removed link, much nicer.