### PR TITLE
INTG-495 DH ensure public key received is not below 2 

### DIFF
--- a/Library/Crypto/SPIDiffieHellman.m
+++ b/Library/Crypto/SPIDiffieHellman.m
@@ -23,6 +23,10 @@
                     theirPublicKey:(JKBigInteger *)theirPublicKey
                     yourPrivateKey:(JKBigInteger *)yourPrivateKey {
     
+    JKBigInteger *minValue = [[JKBigInteger alloc] initWithString:@"2"];
+    if (theirPublicKey < minValue) {
+        @throw [NSException exceptionWithName:@"Exception" reason:@"theirPublicKey value is less than 2" userInfo:nil];
+    }
     // s = A**b mod p
     return [theirPublicKey pow:yourPrivateKey andMod:primeP];
 }


### PR DESCRIPTION
Address security vulnerability when receiving a DH public key of 0 or 1.

Throw an exception if the key is below 2. 

https://mx51.atlassian.net/browse/INTG-495