### PR TITLE
Add posrefId in SPIMessage data

### DIFF
--- a/Library/Model/SPITransaction.m
+++ b/Library/Model/SPITransaction.m
@@ -725,9 +725,11 @@
 }
 
 - (SPIMessage *)toMessage {
+    NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
+    [data setValue:_posRefId forKey:@"pos_ref_id"];
     return [[SPIMessage alloc] initWithMessageId:self.signatureRequiredRequestId
                                        eventName:SPISignatureDeclinedKey
-                                            data:nil
+                                            data:data
                                  needsEncryption:true];
 }
 
@@ -748,9 +750,11 @@
 }
 
 - (SPIMessage *)toMessage {
+    NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
+    [data setValue:_posRefId forKey:@"pos_ref_id"];
     return [[SPIMessage alloc] initWithMessageId:self.signatureRequiredRequestId
                                        eventName:SPISignatureAcceptedKey
-                                            data:nil
+                                            data:data
                                  needsEncryption:true];
 }
 


### PR DESCRIPTION
So for the posrefid signature decline fix, i forgot to add it to the SPIMessage data. I found this out by testing 2.9.2 on Ramen POS. I was able to modify the library code inside RamenPOS with this equivalent code change and it worked, so pretty confident this should fix it.

https://mx51.atlassian.net/browse/INTG-627