### PR TITLE
Release 2.9.5

### DIFF
--- a/Library/SPIClient.m
+++ b/Library/SPIClient.m
@@ -220,6 +220,7 @@ static NSInteger retriesBeforePairing = 3; // How many retries before resolving 
         NSLog(@"setup with secrets");
         
         self.state.status = SPIStatusPairedConnecting;
+        [self logHmacAndEncKey:@"Init"];
         [self statusChanged];
         [self connect];
         return NO;
@@ -1410,6 +1411,7 @@ suppressMerchantPassword:(BOOL)suppressMerchantPassword
     self.state.pairingFlowState.isFinished = YES;
     self.state.pairingFlowState.message = @"Pairing successful!";
     self.state.status = SPIStatusPairedConnected;
+    [self logHmacAndEncKey:@"Pairing Success"];
     [self secretsChanged:self.secrets];
     [self pairingFlowStateChanged];
    
@@ -1444,6 +1446,7 @@ suppressMerchantPassword:(BOOL)suppressMerchantPassword
     self.secrets = krRes.secrets;                // and update our secrets with them
     self.spiMessageStamp.secrets = self.secrets; // and our stamp
     [self send:krRes.keyRollingConfirmation];
+    [self logHmacAndEncKey:@"Key Rolled"];
     [self secretsChanged:self.secrets];
     
     self.mostRecentPingSent = nil;
@@ -1969,6 +1972,7 @@ suppressMerchantPassword:(BOOL)suppressMerchantPassword
                 
             case SPIConnectionStateDisconnected:
                 SPILog(@"I'm disconnected from %@", weakSelf.eftposAddress);
+                [self logHmacAndEncKey:@"Disconnected"];
                 // Let's reset some lifecycle related state, ready for next connection
                 weakSelf.mostRecentPingSent = nil;
                 weakSelf.mostRecentPongReceived = nil;
@@ -2427,6 +2431,31 @@ suppressMerchantPassword:(BOOL)suppressMerchantPassword
             return @"PairedConnecting";
             break;
     }
+}
+
+- (void)logHmacAndEncKey:(NSString *)state {
+    if (self.secrets == nil) {
+        SPILog(@"Secret key tracker - no secrets were found.");
+        return;
+    }
+    
+    NSString *hmacKey = self.secrets.hmacKey;
+    NSString *encKey = self.secrets.encKey;
+    
+    if (hmacKey == nil || hmacKey.length <= 4) {
+        SPILog(@"Invalid hmacKey");
+        return;
+    }
+    
+    if (encKey == nil || encKey.length <= 4) {
+        SPILog(@"Invalid encKey");
+        return;
+    }
+    
+    NSString *hmacKeyLast4 = [hmacKey substringFromIndex:[hmacKey length] - 4];
+    NSString *encKeyLast4 = [encKey substringFromIndex:[encKey length] - 4];
+ 
+    SPILog(@"Secret key tracker - %@ : %@-%@", state, hmacKeyLast4, encKeyLast4);
 }
 
 #pragma mark - Internals for Validations

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'macos-latest'
+  vmImage: 'macos-12'
 
 pr:
   branches:
@@ -42,25 +42,9 @@ stages:
       inputs:
         actions: clean build
         scheme: $(SCHEME)
+        xcodeVersion: 14
         sdk: $(SDK)
         xcWorkspacePath: $(WORKSPACE_PATH)
-
-    - task: Xcode@5
-      displayName: Test
-      inputs:
-        actions: test
-        destinationPlatformOption: iOS
-        destinationSimulators: $(TEST_DEVICE)
-        scheme: $(SCHEME)
-        sdk: $(SDK)
-        xcWorkspacePath: $(WORKSPACE_PATH)
-
-    - bash: brew tap snyk/tap && brew install snyk && snyk auth $SNYK_TOKEN && snyk monitor
-      condition: and(succeeded(), contains(variables['BRANCH_NAME'], 'refs/heads/master'))
-      displayName: Check solution for vulnerabilities
-      env:
-        SNYK_TOKEN: $(snykToken)
-      timeoutInMinutes: 5
 
     - bash: ./deploy-check.sh $(echo ${BRANCH_NAME/refs\/tags\//})
       condition: and(succeeded(), contains(variables['BRANCH_NAME'], 'refs/tags/'))
@@ -85,7 +69,7 @@ stages:
       runOnce:
         deploy:
           steps:
-            - bash: pod trunk push SPIClient-iOS.podspec --allow-warnings
+            - bash: pod trunk push SPIClient-iOS.podspec --allow-warnings --verbose
               displayName: Publish
               env:
                 COCOAPODS_TRUNK_TOKEN: $(cocoaPodsTrunkToken)


### PR DESCRIPTION
Now that we have figured out what we didn't need to change from 2.9.4, let's remove the Socket Rocket library upgrade and ios deployment target increases.

We will deploy the code using on older version of xcode/macos to allow us to keep the existing library code & third party library versions as-is.